### PR TITLE
Fix formatting of keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,3 +1,5 @@
 PersistenceDictionary	KEYWORD2
 Begin	KEYWORD2
-GetValue	KEYWORD2SetValue	KEYWORD2DeleteValue
+GetValue	KEYWORD2
+SetValue	KEYWORD2
+DeleteValue	KEYWORD2


### PR DESCRIPTION
Some newlines were missing, which caused the keywords to not be recognized by the Arduino IDE.